### PR TITLE
Fix duplicate httpx entry

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -65,7 +65,6 @@ croniter==2.0.1
 pytest==7.4.3
 pytest-asyncio==0.21.1
 pytest-cov==4.1.0
-httpx==0.25.2
 
 # Development tools
 black==23.11.0


### PR DESCRIPTION
## Summary
- de-duplicate `httpx` in backend requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: BackendUnavailable: Cannot import 'setuptools.build_meta')*

------
https://chatgpt.com/codex/tasks/task_e_6846eb109ec0832398f44b156d8bd05e